### PR TITLE
Add AGENTS.md with Java/Gradle coding agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# Coding Agent Instructions
+
+## Java and Gradle
+
+- Use JDK 17 for all Gradle commands in this repository. The Gradle wrapper is pinned to Gradle
+  7.2, which cannot run on newer JDKs such as JDK 25.
+- Before running Gradle, verify the active runtime with `java -version`. If necessary in the Codex
+  environment, select its installed JDK 17 with:
+
+  ```bash
+  export JAVA_HOME=/root/.local/share/mise/installs/java/17.0.2
+  export PATH="$JAVA_HOME/bin:$PATH"
+  ```
+
+- Run the normal build from the repository root with `./gradlew build`. The root project itself has
+  only group and version metadata, but `settings.gradle.kts` includes the `structure` subproject.
+  Gradle resolves the unqualified `build` task to `:structure:build`.
+- Do not conclude that a root `./gradlew build` skips the implementation. The Java plugin,
+  dependencies, Spotless configuration, and JUnit Platform setup intentionally live in
+  `structure/build.gradle.kts`, next to the sources under `structure/src`.
+- If Gradle reports that the Spotless plugin or another dependency cannot be resolved, first check
+  access to the Gradle Plugin Portal and Maven Central. A proxy or restricted network can cause
+  this failure before compilation; it does not mean the subproject is wired incorrectly.
+- When diagnosing build behavior, prefer `./gradlew clean build --console=plain` and report whether
+  failure occurred during plugin/dependency resolution, compilation, testing, or formatting.


### PR DESCRIPTION
### Motivation

- Provide explicit environment and workflow guidance for automated coding agents operating on this repository.
- Reduce build and troubleshooting friction by documenting the required JDK, Gradle wrapper constraints, and common failure modes.

### Description

- Add `AGENTS.md` containing instructions to use JDK 17 and noting that the Gradle wrapper is pinned to Gradle 7.2.
- Document how to verify and select the runtime with `java -version` and the example `export JAVA_HOME=...` and `export PATH=...` commands.
- Explain the recommended build invocation `./gradlew build`, where the actual Java plugin and sources live under `structure/`, and why the root `build` maps to `:structure:build`.
- Include troubleshooting advice about plugin/dependency resolution failures and recommend using `./gradlew clean build --console=plain` when diagnosing failures.

### Testing

- No automated tests were executed as part of this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a681f5c5898832d8eac8ca3b57f78da)