### PR TITLE
Support differing operand/result domains for binary operators and implement truth-valued Equality with tests

### DIFF
--- a/structure/src/main/java/formallogic/structure/common/AbstractBinaryOperator.java
+++ b/structure/src/main/java/formallogic/structure/common/AbstractBinaryOperator.java
@@ -15,9 +15,14 @@ public abstract class AbstractBinaryOperator<T extends Domain> extends AbstractT
   private final Set<Variable> variables;
 
   protected AbstractBinaryOperator(Term leftOperand, Term rightOperand, T domain) {
-    super(domain);
-    assert leftOperand.domain().equals(domain) : "leftOperand";
-    assert rightOperand.domain().equals(domain) : "rightOperand";
+    this(leftOperand, rightOperand, domain, domain);
+  }
+
+  protected AbstractBinaryOperator(
+      Term leftOperand, Term rightOperand, Domain operandDomain, T resultDomain) {
+    super(resultDomain);
+    assert leftOperand.domain().equals(operandDomain) : "leftOperand";
+    assert rightOperand.domain().equals(operandDomain) : "rightOperand";
     this.leftOperand = leftOperand;
     this.rightOperand = rightOperand;
     variables =

--- a/structure/src/main/java/formallogic/structure/formula/Equality.java
+++ b/structure/src/main/java/formallogic/structure/formula/Equality.java
@@ -1,12 +1,14 @@
 package formallogic.structure.formula;
 
+import formallogic.structure.common.AbstractBinaryOperator;
 import formallogic.structure.core.Term;
 import formallogic.structure.core.Variable;
+import formallogic.structure.domains.TruthDomain;
 
-public final class Equality extends BinaryConnective {
+public final class Equality extends AbstractBinaryOperator<TruthDomain> {
 
   Equality(Term leftOperand, Term rightOperand) {
-    super(leftOperand, rightOperand);
+    super(leftOperand, rightOperand, leftOperand.domain(), TruthDomain.TRUTH_DOMAIN);
   }
 
   @Override

--- a/structure/src/test/java/formallogic/structure/formula/BinaryConnectiveTest.java
+++ b/structure/src/test/java/formallogic/structure/formula/BinaryConnectiveTest.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 final class BinaryConnectiveTest extends AbstractBinaryOperatorTest {
   private final List<Class<? extends AbstractBinaryOperator<?>>> classes =
-      Arrays.asList(Conjunction.class, Disjunction.class, Equality.class, Implication.class);
+      Arrays.asList(Conjunction.class, Disjunction.class, Implication.class);
 
   @Override
   protected List<Class<? extends AbstractBinaryOperator<?>>> classes() {

--- a/structure/src/test/java/formallogic/structure/formula/EqualityTest.java
+++ b/structure/src/test/java/formallogic/structure/formula/EqualityTest.java
@@ -1,0 +1,53 @@
+package formallogic.structure.formula;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import formallogic.structure.core.Domain;
+import formallogic.structure.core.Term;
+import formallogic.structure.core.Variable;
+import formallogic.structure.domains.TruthDomain;
+import formallogic.structure.testing.ConstTerm;
+import formallogic.structure.testing.FakeDomain;
+import formallogic.structure.testing.UnaryTerm;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+final class EqualityTest {
+
+  @Test
+  public void acceptsOperandsInSameObjectDomainAndReturnsTruth() {
+    Domain domain = new FakeDomain();
+    Term left = new ConstTerm(domain);
+    Term right = new ConstTerm(domain);
+
+    Equality equality = new Equality(left, right);
+
+    assertThat(equality.leftOperand()).isEqualTo(left);
+    assertThat(equality.rightOperand()).isEqualTo(right);
+    assertThat(equality.domain()).isEqualTo(TruthDomain.TRUTH_DOMAIN);
+  }
+
+  @Test
+  public void rejectsOperandsInDifferentDomains() {
+    Term left = new ConstTerm(new FakeDomain());
+    Term right = new ConstTerm(new FakeDomain());
+
+    assertThrows(AssertionError.class, () -> new Equality(left, right));
+  }
+
+  @Test
+  public void aggregatesVariablesAndSubstitutesOperands() {
+    Domain operandDomain = new FakeDomain();
+    Domain variableDomain = new FakeDomain();
+    Variable variable = new Variable(variableDomain);
+    Term left = new UnaryTerm(variable, operandDomain);
+    Term right = new ConstTerm(operandDomain);
+    Term replacement = new ConstTerm(variableDomain);
+    Equality equality = new Equality(left, right);
+
+    assertThat(equality.variables()).isEqualTo(Set.of(variable));
+    assertThat(equality.substitute(variable, replacement))
+        .isEqualTo(new Equality(left.substitute(variable, replacement), right));
+  }
+}

--- a/structure/src/test/java/formallogic/structure/formula/FormulaBuilderTest.java
+++ b/structure/src/test/java/formallogic/structure/formula/FormulaBuilderTest.java
@@ -30,7 +30,18 @@ final class FormulaBuilderTest {
     assertThat(FormulaBuilder.newBuilder(f).implies(g).build()).isEqualTo(new Implication(f, g));
     assertThat(FormulaBuilder.newBuilder(f).isImpliedBy(g).build())
         .isEqualTo(new Implication(g, f));
-    assertThat(FormulaBuilder.newBuilder(f).equalsTo(g).build()).isEqualTo(new Equality(f, g));
+  }
+
+  @Test
+  public void equalityBuilderTest() {
+    Domain domain = new FakeDomain();
+    Term left = new ConstTerm(domain);
+    Term right = new ConstTerm(domain);
+
+    Term equality = FormulaBuilder.newBuilder(left).equalsTo(right).build();
+
+    assertThat(equality).isEqualTo(new Equality(left, right));
+    assertThat(equality.domain()).isEqualTo(TruthDomain.TRUTH_DOMAIN);
   }
 
   @Test


### PR DESCRIPTION
### Motivation
- Enable binary operators whose operand domain differs from their result domain so connectives like `Equality` can return a `TruthDomain` while accepting arbitrary object domains.

### Description
- Add a new `AbstractBinaryOperator` constructor `AbstractBinaryOperator(Term left, Term right, Domain operandDomain, T resultDomain)` and route the old constructor to it.  
- Change `Equality` to extend `AbstractBinaryOperator<TruthDomain>` and construct it with the operands' domain as the operand domain and `TruthDomain.TRUTH_DOMAIN` as the result domain.  
- Update tests and test helpers by removing `Equality` from the `BinaryConnectiveTest` list, adding a dedicated `EqualityTest` covering operand validation, variable aggregation and substitution, and adapting `FormulaBuilderTest` to include an `equalityBuilderTest`.  
- Adjust imports to reflect the new class relationships.

### Testing
- Ran unit tests covering `AbstractBinaryOperatorTest`, `BinaryConnectiveTest`, `EqualityTest`, and `FormulaBuilderTest`.  
- All listed tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a716c929720832da4a2f7386693ea60)