### PR TITLE
Update Spotless Gradle plugin to 6.25.0

### DIFF
--- a/structure/build.gradle.kts
+++ b/structure/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   java
-  id("com.diffplug.spotless") version "6.10.0"
+  id("com.diffplug.spotless") version "6.25.0"
 }
 
 repositories {


### PR DESCRIPTION
### Motivation
- Use a Spotless release that is compatible with the repository's Gradle wrapper `7.2`, since the `8.x` line requires Gradle `7.3+`, so `6.25.0` is the safest recent `6.x` choice.

### Description
- Replace `com.diffplug.spotless` version in `structure/build.gradle.kts` from `6.10.0` to `6.25.0` and commit the change.

### Testing
- Ran `./gradlew build --console=plain` with `JAVA_HOME` set to JDK 17 which failed during plugin resolution due to blocked access to the Gradle Plugin Portal and not due to compilation or tests.
- Verified repository state with `git diff --check` and `git log -1 --oneline`, which show a clean diff and the commit updating the plugin version.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72b5c0053c832d9ced67da53fb19dc)