### PR TITLE
Require Spotless formatting for Java (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,10 @@
 # Coding Agent Instructions
 
+## Java Formatting
+
+- Before completing any Java changes, run `./gradlew spotlessApply` from the repository root.
+- Never leave Java files unformatted. Always let Spotless/Google Java Format decide formatting, and never format Java files by other means.
+
 ## Java and Gradle
 
 - Use JDK 17 for all Gradle commands in this repository. The Gradle wrapper is pinned to Gradle


### PR DESCRIPTION
### Motivation
- Ensure Java changes are consistently formatted by Spotless/Google Java Format and prevent manual formatting drift.

### Description
- Add a `Java Formatting` section to `AGENTS.md` requiring running `./gradlew spotlessApply` from the repository root and stating that Java files must not be manually reformatted.

### Testing
- Documentation-only change; no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72bef14e40832d8d8d5690f6cbcf23)